### PR TITLE
fix code for grpc example

### DIFF
--- a/grpc-example/route-client/client.go
+++ b/grpc-example/route-client/client.go
@@ -86,11 +86,16 @@ func runForth(client pb.RouteGuideClient) {
 
 	// this goroutine listen to the server stream
 	go func() {
-		feature, err2 := stream.Recv()
-		if err2 != nil {
-			log.Fatalln(err2)
+		for {
+			feature, err2 := stream.Recv()
+			if err2 == io.EOF {
+				break
+			}
+			if err2 != nil {
+				log.Fatalln(err2)
+			}
+			fmt.Println("Recommended: ", feature)
 		}
-		fmt.Println("Recommended: ", feature)
 	}()
 
 	reader := bufio.NewReader(os.Stdin)

--- a/grpc-example/route-server/server.go
+++ b/grpc-example/route-server/server.go
@@ -143,7 +143,10 @@ func (s *routeGuideServer) Recommend(stream pb.RouteGuide_RecommendServer) error
 		if err != nil {
 			return err
 		}
-		return stream.Send(recommended)
+		err = stream.Send(recommended)
+		if err != nil {
+			return err
+		}
 	}
 }
 


### PR DESCRIPTION
修复了grpc的bug：
1. 在client增加循环接收的for loop
2. 去除server中发送后直接return的愚蠢的错误

